### PR TITLE
fix: 修复前置摄像头视频方向颠倒与同名照片错误配对

### DIFF
--- a/src/LivePhotoConvert.Cli/Program.cs
+++ b/src/LivePhotoConvert.Cli/Program.cs
@@ -203,11 +203,13 @@ public static class Program
         WarnIfSameDirectory(input, output);
 
         var pairing = MediaPairMatcher.Match(Directory.EnumerateFiles(input, "*", SearchOption.TopDirectoryOnly));
-        Console.WriteLine($"匹配到 {pairing.Pairs.Count} 组动态照片。");
+        var matchedGroupCount = pairing.Pairs.Select(pair => pair.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count();
+        Console.WriteLine($"匹配到 {matchedGroupCount} 组动态照片。");
         Console.WriteLine($"未匹配的照片 {pairing.UnmatchedPhotoCount} 个，未匹配的视频 {pairing.UnmatchedVideoCount} 个，均不会被合成或清理。");
-        if (pairing.SkippedDuplicateCount > 0)
+        var duplicateCandidateCount = pairing.Pairs.Count - matchedGroupCount;
+        if (duplicateCandidateCount > 0)
         {
-            Console.WriteLine($"另有 {pairing.SkippedDuplicateCount} 个同名备选格式文件未参与合成，也不会被清理。");
+            Console.WriteLine($"另有 {duplicateCandidateCount} 个同名候选将参与智能校验，仅与视频匹配的那组会被合成。");
         }
 
         if (pairing.Pairs.Count == 0)

--- a/src/LivePhotoConvert.Core/Abstractions/IExifTool.cs
+++ b/src/LivePhotoConvert.Core/Abstractions/IExifTool.cs
@@ -84,4 +84,17 @@ public interface IExifTool : IAsyncDisposable
     /// <param name="cancellationToken">取消令牌</param>
     /// <returns>视频时长；无法读取时返回 <c>null</c></returns>
     Task<TimeSpan?> TryReadDurationAsync(string filePath, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// 判断视频是否带镜像变换矩阵（iPhone 前置摄像头视频的典型特征）
+    /// </summary>
+    /// <remarks>
+    /// 前置摄像头视频的 QuickTime 变换矩阵行列式为负（含镜像），
+    /// 安卓相册等 MP4 播放器不识别镜像矩阵，会导致内嵌视频方向颠倒，
+    /// 因此需要检测出来改走重新编码把方向烧进像素。
+    /// </remarks>
+    /// <param name="videoPath">视频文件路径</param>
+    /// <param name="cancellationToken">取消令牌</param>
+    /// <returns>是否含镜像矩阵；无法读取时返回 <c>false</c>（按无需镜像处理）</returns>
+    Task<bool> IsMirroredVideoAsync(string videoPath, CancellationToken cancellationToken = default);
 }

--- a/src/LivePhotoConvert.Core/Abstractions/IMediaConverter.cs
+++ b/src/LivePhotoConvert.Core/Abstractions/IMediaConverter.cs
@@ -25,8 +25,9 @@ public interface IVideoConverter
     /// <remarks>优先无损换容器，失败时回退到重新编码。</remarks>
     /// <param name="sourcePath">源视频路径</param>
     /// <param name="destinationPath">目标路径</param>
+    /// <param name="forceTranscode">强制重新编码；前置摄像头视频带镜像矩阵时需转码烧入方向</param>
     /// <param name="cancellationToken">取消令牌</param>
-    Task ConvertToMp4Async(string sourcePath, string destinationPath, CancellationToken cancellationToken = default);
+    Task ConvertToMp4Async(string sourcePath, string destinationPath, bool forceTranscode = false, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// 将视频转换为 Apple QuickTime MOV 格式

--- a/src/LivePhotoConvert.Core/External/ExifTool.cs
+++ b/src/LivePhotoConvert.Core/External/ExifTool.cs
@@ -258,6 +258,60 @@ public sealed class ExifTool : IExifTool
         return null;
     }
 
+    /// <inheritdoc />
+    public async Task<bool> IsMirroredVideoAsync(string videoPath, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // 读取所有轨道的变换矩阵，任一轨道带镜像（行列式为负）即视为镜像视频。
+            // 后置摄像头视频的矩阵是恒等或纯旋转（行列式为正），只有前置摄像头才会出现镜像矩阵。
+            List<string> arguments = ["-a", "-s3", "-MatrixStructure", videoPath];
+            var response = await _session.ExecuteAsync(arguments, cancellationToken);
+            foreach (var line in response.StandardOutput.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                if (TryParseMatrixDeterminant(line, out var determinant) && determinant < 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch (Exception)
+        {
+            // 矩阵读取失败时按无需镜像处理，保持原有的无损换容器行为
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 解析 ExifTool 输出的 MatrixStructure 行并计算行列式 (a*d - b*c)
+    /// </summary>
+    /// <param name="line">形如 "0 1 0 1 0 0 0 0 1" 的 3x3 矩阵行</param>
+    /// <param name="determinant">行列式值</param>
+    /// <returns>是否成功解析</returns>
+    private static bool TryParseMatrixDeterminant(string line, out double determinant)
+    {
+        determinant = 0;
+        var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length < 5)
+        {
+            return false;
+        }
+
+        // 3x3 矩阵按行主序输出：a b u / c d v / x y w，镜像只取决于 a、b、c、d
+        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var a)
+            || !double.TryParse(parts[1], NumberStyles.Float, CultureInfo.InvariantCulture, out var b)
+            || !double.TryParse(parts[3], NumberStyles.Float, CultureInfo.InvariantCulture, out var c)
+            || !double.TryParse(parts[4], NumberStyles.Float, CultureInfo.InvariantCulture, out var d))
+        {
+            return false;
+        }
+
+        determinant = a * d - b * c;
+        return true;
+    }
+
     /// <summary>
     /// 解析 ExifTool 输出的日期字符串
     /// </summary>

--- a/src/LivePhotoConvert.Core/External/FfmpegVideoConverter.cs
+++ b/src/LivePhotoConvert.Core/External/FfmpegVideoConverter.cs
@@ -35,18 +35,26 @@ public sealed class FfmpegVideoConverter : IVideoConverter, IImageConverter
     }
 
     /// <inheritdoc />
-    public async Task ConvertToMp4Async(string sourcePath, string destinationPath, CancellationToken cancellationToken = default)
+    public async Task ConvertToMp4Async(string sourcePath, string destinationPath, bool forceTranscode = false, CancellationToken cancellationToken = default)
     {
-        // iPhone 的 MOV 本身就是 H.264/HEVC + AAC，换容器即可，无需重新编码
-        var remux = await ProcessRunner.RunAsync(_executablePath, BuildRemuxArguments(sourcePath, destinationPath), cancellationToken);
-        if (remux.Success)
+        string? remuxError = null;
+        if (!forceTranscode)
         {
-            return;
+            // iPhone 的 MOV 本身就是 H.264/HEVC + AAC，换容器即可，无需重新编码
+            var remux = await ProcessRunner.RunAsync(_executablePath, BuildRemuxArguments(sourcePath, destinationPath), cancellationToken);
+            if (remux.Success)
+            {
+                return;
+            }
+
+            // 换容器失败（例如编码格式不被 MP4 容器接受），回退到重新编码
+            remuxError = Summarize(remux.StandardError);
+            TryDeletePartialOutput(destinationPath);
         }
 
-        // 换容器失败（例如编码格式不被 MP4 容器接受），回退到重新编码
-        TryDeletePartialOutput(destinationPath);
-
+        // 强制转码时跳过换容器：前置摄像头视频带镜像矩阵（行列式为负），
+        // 安卓相册等 MP4 播放器不识别镜像矩阵，只有重新编码才能让 FFmpeg 的
+        // autorotate 把镜像与旋转一起烧进像素，输出无方向元数据的标准 MP4。
         var transcode = await ProcessRunner.RunAsync(_executablePath, BuildTranscodeArguments(sourcePath, destinationPath), cancellationToken);
         if (transcode.Success)
         {
@@ -54,7 +62,8 @@ public sealed class FfmpegVideoConverter : IVideoConverter, IImageConverter
         }
 
         TryDeletePartialOutput(destinationPath);
-        throw new InvalidOperationException($"FFmpeg 转换视频失败。换容器错误：{Summarize(remux.StandardError)}；重新编码错误：{Summarize(transcode.StandardError)}");
+        var remuxDescription = forceTranscode ? "强制转码（前置镜像视频）" : $"换容器错误：{remuxError}";
+        throw new InvalidOperationException($"FFmpeg 转换视频失败。{remuxDescription}；重新编码错误：{Summarize(transcode.StandardError)}");
     }
 
     /// <inheritdoc />

--- a/src/LivePhotoConvert.Core/Matching/MediaPairMatcher.cs
+++ b/src/LivePhotoConvert.Core/Matching/MediaPairMatcher.cs
@@ -19,20 +19,40 @@ public static class MediaPairMatcher
         var files = filePaths.ToList();
         var photos = files.Where(MediaFileTypes.IsPhoto).ToList();
         var videos = files.Where(MediaFileTypes.IsVideo).ToList();
-        // 同名多格式（如 IMG_0001.heic 与 IMG_0001.jpg）只保留优先级最高的一个，避免同一张照片被匹配成多组
-        var uniquePhotos = PickPreferredByName(photos, MediaFileTypes.PhotoExtensionPriority);
-        var uniqueVideos = PickPreferredByName(videos, MediaFileTypes.VideoExtensionPriority);
-        var pairs = uniquePhotos.Join(uniqueVideos, GetNameKey, GetNameKey, (photoPath, videoPath) => new MediaPair(photoPath, videoPath), StringComparer.OrdinalIgnoreCase).ToList();
+
+        var photosByName = photos.GroupBy(GetNameKey, StringComparer.OrdinalIgnoreCase);
+        var videosByName = videos.GroupBy(GetNameKey, StringComparer.OrdinalIgnoreCase)
+                                 .ToDictionary(group => group.Key, group => group.ToList(), StringComparer.OrdinalIgnoreCase);
+
+        // 同名文件可能存在多个格式（如 IMG_0001.heic 与 IMG_0001.jpg），
+        // 全部保留为候选并按扩展名优先级排序，合成阶段会校验并只取每组第一个通过者。
+        // 这样既能优先取画质更好的格式，又能在同名不同内容的照片里选对与视频真正匹配的那张。
+        var pairs = new List<MediaPair>();
+        foreach (var photoGroup in photosByName)
+        {
+            if (!videosByName.TryGetValue(photoGroup.Key, out var sameNameVideos))
+            {
+                continue;
+            }
+
+            var orderedPhotos = photoGroup.OrderBy(GetPhotoRank).ThenBy(filePath => filePath, StringComparer.OrdinalIgnoreCase);
+            var orderedVideos = sameNameVideos.OrderBy(GetVideoRank).ThenBy(filePath => filePath, StringComparer.OrdinalIgnoreCase);
+            foreach (var photo in orderedPhotos)
+            {
+                foreach (var video in orderedVideos)
+                {
+                    pairs.Add(new MediaPair(photo, video));
+                }
+            }
+        }
+
         // 统计未匹配的文件，它们在任何清理选项下都不会被处理
-        var matchedNames = new HashSet<string>(pairs.Select(pair => GetNameKey(pair.PhotoPath)), StringComparer.OrdinalIgnoreCase);
-        var matchedFiles = new HashSet<string>(pairs.SelectMany(pair => new[] { pair.PhotoPath, pair.VideoPath }), StringComparer.OrdinalIgnoreCase);
+        var matchedNames = new HashSet<string>(pairs.Select(pair => pair.Name), StringComparer.OrdinalIgnoreCase);
         return new PairingResult
         {
             Pairs = pairs,
-            UnmatchedPhotoCount = photos.Count(f => !matchedNames.Contains(GetNameKey(f))),
-            UnmatchedVideoCount = videos.Count(f => !matchedNames.Contains(GetNameKey(f))),
-            // 同名但未被选中的备选格式，只清理实际参与合成的那个文件，这些一律保留
-            SkippedDuplicateCount = photos.Concat(videos).Count(f => matchedNames.Contains(GetNameKey(f)) && !matchedFiles.Contains(f))
+            UnmatchedPhotoCount = photos.Count(filePath => !matchedNames.Contains(GetNameKey(filePath))),
+            UnmatchedVideoCount = videos.Count(filePath => !matchedNames.Contains(GetNameKey(filePath)))
         };
     }
 
@@ -44,21 +64,21 @@ public static class MediaPairMatcher
     private static string GetNameKey(string filePath) => Path.GetFileNameWithoutExtension(filePath);
 
     /// <summary>
-    /// 同名文件按扩展名优先级只保留一个
+    /// 照片扩展名优先级
     /// </summary>
-    /// <param name="files">文件列表</param>
-    /// <param name="extensionPriority">扩展名优先级，越靠前优先级越高</param>
-    /// <returns>去重后的文件列表</returns>
-    private static List<string> PickPreferredByName(List<string> files, string[] extensionPriority)
-    {
-        return files.GroupBy(GetNameKey, StringComparer.OrdinalIgnoreCase)
-                    .Select(group => group.OrderBy(GetExtensionRank).ThenBy(f => f, StringComparer.OrdinalIgnoreCase).First())
-                    .ToList();
+    private static int GetPhotoRank(string filePath) => GetExtensionRank(filePath, MediaFileTypes.PhotoExtensionPriority);
 
-        int GetExtensionRank(string filePath)
-        {
-            var rank = Array.FindIndex(extensionPriority, e => e.Equals(Path.GetExtension(filePath), StringComparison.OrdinalIgnoreCase));
-            return rank < 0 ? extensionPriority.Length : rank;
-        }
+    /// <summary>
+    /// 视频扩展名优先级
+    /// </summary>
+    private static int GetVideoRank(string filePath) => GetExtensionRank(filePath, MediaFileTypes.VideoExtensionPriority);
+
+    /// <summary>
+    /// 扩展名在优先级列表中的排名，越靠前排名越小
+    /// </summary>
+    private static int GetExtensionRank(string filePath, string[] extensionPriority)
+    {
+        var rank = Array.FindIndex(extensionPriority, extension => extension.Equals(Path.GetExtension(filePath), StringComparison.OrdinalIgnoreCase));
+        return rank < 0 ? extensionPriority.Length : rank;
     }
 }

--- a/src/LivePhotoConvert.Core/Models/MediaPair.cs
+++ b/src/LivePhotoConvert.Core/Models/MediaPair.cs
@@ -19,8 +19,12 @@ public sealed record MediaPair(string PhotoPath, string VideoPath)
 public sealed record PairingResult
 {
     /// <summary>
-    /// 匹配成功、可以参与合成的分组
+    /// 待合成的候选分组，按文件名与扩展名优先级排序
     /// </summary>
+    /// <remarks>
+    /// 同名文件可能存在多个候选（例如同时存在 IMG_0001.heic、IMG_0001.jpg 与 IMG_0001.mov），
+    /// 合成阶段会逐个校验并只取每组中第一个通过校验的候选。
+    /// </remarks>
     public required IReadOnlyList<MediaPair> Pairs { get; init; }
 
     /// <summary>
@@ -32,9 +36,4 @@ public sealed record PairingResult
     /// 未匹配到照片的视频数量（例如 iPhone 导出的长视频），这些文件不会被合成或清理
     /// </summary>
     public required int UnmatchedVideoCount { get; init; }
-
-    /// <summary>
-    /// 同名但因扩展名优先级较低而未参与合成的备选文件数量，这些文件同样不会被清理
-    /// </summary>
-    public required int SkippedDuplicateCount { get; init; }
 }

--- a/src/LivePhotoConvert.Core/Services/MotionPhotoMerger.cs
+++ b/src/LivePhotoConvert.Core/Services/MotionPhotoMerger.cs
@@ -42,7 +42,9 @@ public sealed class MotionPhotoMerger(IExifTool exifTool, IImageConverter imageC
         var cleanupFailures = new ConcurrentBag<FailureRecord>();
         var skippedItems = new ConcurrentBag<FailureRecord>();
         var validator = options.SkipValidation ? null : new PairValidator(exifTool);
-        var total = pairing.Pairs.Count;
+        var candidates = pairing.Pairs;
+        // 同名文件可能生成多个候选（按扩展名优先级排序），最终每个文件名只合成一组
+        var total = candidates.Select(pair => pair.Name).Distinct(StringComparer.OrdinalIgnoreCase).Count();
         var completed = 0;
         var succeeded = 0;
         var cleanedFiles = 0;
@@ -51,25 +53,50 @@ public sealed class MotionPhotoMerger(IExifTool exifTool, IImageConverter imageC
         Directory.CreateDirectory(tempDirectory);
         try
         {
+            // ── 阶段 1：并行校验所有候选，判断照片与视频是否确属同一张实况照片 ──
+            var validations = new ConcurrentDictionary<MediaPair, PairValidationResult>();
             await Parallel.ForEachAsync(
-                pairing.Pairs,
+                candidates,
+                new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism, CancellationToken = cancellationToken },
+                async (pair, token) =>
+                {
+                    var result = validator is null
+                        ? PairValidationResult.Accept([])
+                        : await validator.ValidateAsync(pair, token);
+                    validations[pair] = result;
+                });
+
+            // ── 阶段 2：按文件名分组，每组选第一个校验通过的候选 ──
+            // 候选已按扩展名优先级排序，因此同名多格式（如 .heic 与 .jpg）优先取画质更好的；
+            // 若首选与视频并非同一张实况照片（校验不通过），自动回退到同名的下一个候选。
+            var chosen = new List<MediaPair>();
+            foreach (var group in candidates.GroupBy(pair => pair.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                var selected = group.FirstOrDefault(pair => validations[pair].IsAccepted);
+                if (selected is null)
+                {
+                    foreach (var pair in group)
+                    {
+                        skippedItems.Add(new FailureRecord(group.Key, string.Join("；", validations[pair].Reasons)));
+                    }
+                    continue;
+                }
+
+                chosen.Add(selected);
+                foreach (var other in group.Where(pair => !pair.Equals(selected)))
+                {
+                    skippedItems.Add(new FailureRecord(group.Key, $"同名候选 {Path.GetFileName(other.PhotoPath)} 未采用，已选用 {Path.GetFileName(selected.PhotoPath)}"));
+                }
+            }
+
+            // ── 阶段 3：并行合成选中的分组 ──
+            await Parallel.ForEachAsync(
+                chosen,
                 new ParallelOptions { MaxDegreeOfParallelism = options.Parallelism, CancellationToken = cancellationToken },
                 async (pair, token) =>
                 {
                     try
                     {
-                        // 配对校验：不通过时跳过该组，不中断整体流程
-                        if (validator is not null)
-                        {
-                            var validation = await validator.ValidateAsync(pair, token);
-                            if (!validation.IsAccepted)
-                            {
-                                var reason = string.Join("；", validation.Reasons);
-                                skippedItems.Add(new FailureRecord(pair.Name, reason));
-                                return;
-                            }
-                        }
-
                         await MergeOneAsync(pair, options, tempDirectory, token);
                         Interlocked.Increment(ref succeeded);
                         // 只有合成成功并通过校验的这一组才会被清理，未匹配的文件绝不会进入这里
@@ -138,7 +165,9 @@ public sealed class MotionPhotoMerger(IExifTool exifTool, IImageConverter imageC
             if (!MediaFileTypes.IsMp4(videoPath))
             {
                 temporaryVideo = Path.Combine(tempDirectory, $"{Guid.NewGuid():N}.mp4");
-                await videoConverter.ConvertToMp4Async(videoPath, temporaryVideo, cancellationToken);
+                // 前置摄像头视频带镜像矩阵，安卓播放器不识别，需转码把方向烧进像素
+                var isMirrored = await exifTool.IsMirroredVideoAsync(videoPath, cancellationToken);
+                await videoConverter.ConvertToMp4Async(videoPath, temporaryVideo, isMirrored, cancellationToken);
                 videoPath = temporaryVideo;
             }
 

--- a/src/LivePhotoConvert.Core/Services/PairValidator.cs
+++ b/src/LivePhotoConvert.Core/Services/PairValidator.cs
@@ -8,8 +8,8 @@ namespace LivePhotoConvert.Core.Services;
 /// </summary>
 /// <remarks>
 /// 依次检查 ContentIdentifier、拍摄时间差、视频时长三个维度。
-/// 任一维度明确否定即拒绝；所有可评估维度均为可疑时也拒绝；
-/// 全部维度不可评估时降级为仅文件名匹配（通过）。
+/// ContentIdentifier 单边存在或明确不一致时直接拒绝；时间差与视频时长异常时记为可疑；
+/// 所有可评估维度均为可疑时也拒绝；全部维度不可评估时降级为仅文件名匹配（通过）。
 /// </remarks>
 /// <param name="exifTool">元数据读写</param>
 public sealed class PairValidator(IExifTool exifTool)
@@ -70,7 +70,10 @@ public sealed class PairValidator(IExifTool exifTool)
             }
             else
             {
-                reasons.Add($"仅{(photoId is not null ? "照片" : "视频")}含 ContentIdentifier，跳过此项校验");
+                // 真正的实况照片，照片与视频必然带有相同的 ContentIdentifier；
+                // 仅单边存在强烈暗示二者并非同一张实况照片，直接拒绝，避免错配合成
+                reasons.Add($"仅{(photoId is not null ? "照片" : "视频")}含 ContentIdentifier，不像是同一张实况照片");
+                return PairValidationResult.Reject(reasons);
             }
         }
         catch (Exception)

--- a/tests/LivePhotoConvert.Core.Tests/MediaPairMatcherTests.cs
+++ b/tests/LivePhotoConvert.Core.Tests/MediaPairMatcherTests.cs
@@ -22,12 +22,12 @@ public class MediaPairMatcherTests
     }
 
     /// <summary>
-    /// 测试当同一项目存在多种照片格式（如 HEIC 和 JPG）时，会选择优先级更高的一种（HEIC）。
+    /// 测试当同一项目存在多种照片格式（如 HEIC 和 JPG）时，会生成多个候选，
+    /// 且画质更好的 HEIC 排在前面（合成阶段校验通过时优先取用）。
     /// </summary>
     [Fact]
-    public void Should_Prioritize_Heic_Over_Jpg_When_Multiple_Formats_Exist()
+    public void Should_Generate_Candidates_Prioritizing_Heic_Over_Jpg_When_Multiple_Formats_Exist()
     {
-        // 从 iPhone 导出时常见 HEIC 与 JPG 并存，应该只用画质更好的 HEIC 合成一组
         var result = MediaPairMatcher.Match(
         [
             @"D:\in\IMG_0001.jpg",
@@ -35,10 +35,31 @@ public class MediaPairMatcherTests
             @"D:\in\IMG_0001.mov"
         ]);
 
-        var pair = Assert.Single(result.Pairs);
-        Assert.Equal(@"D:\in\IMG_0001.heic", pair.PhotoPath);
-        // 落选的 JPG 不参与合成，也不能被当作已匹配文件清理掉
-        Assert.Equal(1, result.SkippedDuplicateCount);
+        Assert.Equal(2, result.Pairs.Count);
+        Assert.Equal(@"D:\in\IMG_0001.heic", result.Pairs[0].PhotoPath);
+        Assert.Equal(@"D:\in\IMG_0001.jpg", result.Pairs[1].PhotoPath);
+        Assert.All(result.Pairs, pair => Assert.Equal(@"D:\in\IMG_0001.mov", pair.VideoPath));
+    }
+
+    /// <summary>
+    /// 测试同名但扩展名不同的两张照片会生成多个候选，供合成阶段按校验结果选择
+    /// </summary>
+    [Fact]
+    public void Should_Generate_Multiple_Candidates_For_Same_Name_Different_Content()
+    {
+        // IMG_0435.jpg（无 ContentIdentifier 的无关照片）与 IMG_0435.jpeg（真正的实况照片）同名，
+        // 两者都应作为候选保留，合成阶段再通过 ContentIdentifier 等信号选对的那张
+        var result = MediaPairMatcher.Match(
+        [
+            @"D:\in\IMG_0435.jpg",
+            @"D:\in\IMG_0435.jpeg",
+            @"D:\in\IMG_0435.mov"
+        ]);
+
+        Assert.Equal(2, result.Pairs.Count);
+        // .jpg 扩展名优先级高于 .jpeg，因此排在前面
+        Assert.Equal(@"D:\in\IMG_0435.jpg", result.Pairs[0].PhotoPath);
+        Assert.Equal(@"D:\in\IMG_0435.jpeg", result.Pairs[1].PhotoPath);
     }
 
     /// <summary>
@@ -99,14 +120,13 @@ public class MediaPairMatcherTests
         Assert.Single(result.Pairs);
         Assert.Equal(0, result.UnmatchedPhotoCount);
         Assert.Equal(0, result.UnmatchedVideoCount);
-        Assert.Equal(0, result.SkippedDuplicateCount);
     }
 
     /// <summary>
-    /// 测试当同一项目存在多种视频格式（如 MP4 和 MOV）时，会选择优先级更高的一种（MOV）。
+    /// 测试当同一项目存在多种视频格式（如 MP4 和 MOV）时，会生成多个候选，且 MOV 排在前面。
     /// </summary>
     [Fact]
-    public void Should_Prioritize_Mov_Over_Mp4_When_Multiple_Formats_Exist()
+    public void Should_Generate_Candidates_Prioritizing_Mov_Over_Mp4_When_Multiple_Formats_Exist()
     {
         var result = MediaPairMatcher.Match(
         [
@@ -115,9 +135,10 @@ public class MediaPairMatcherTests
             @"D:\in\IMG_0001.mov"
         ]);
 
-        var pair = Assert.Single(result.Pairs);
-        Assert.Equal(@"D:\in\IMG_0001.mov", pair.VideoPath);
-        Assert.Equal(1, result.SkippedDuplicateCount);
+        Assert.Equal(2, result.Pairs.Count);
+        Assert.Equal(@"D:\in\IMG_0001.mov", result.Pairs[0].VideoPath);
+        Assert.Equal(@"D:\in\IMG_0001.mp4", result.Pairs[1].VideoPath);
+        Assert.All(result.Pairs, pair => Assert.Equal(@"D:\in\IMG_0001.jpg", pair.PhotoPath));
     }
 
     /// <summary>

--- a/tests/LivePhotoConvert.Core.Tests/PairValidatorTests.cs
+++ b/tests/LivePhotoConvert.Core.Tests/PairValidatorTests.cs
@@ -49,6 +49,31 @@ public class PairValidatorTests
     }
 
     /// <summary>
+    /// 仅照片或仅视频单边含 ContentIdentifier 时应拒绝，避免把不相关的照片与视频错配合成
+    /// </summary>
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public async Task Should_Reject_When_Only_One_Side_Has_ContentIdentifier(bool photoHasId, bool videoHasId)
+    {
+        var exifTool = new FakeExifTool();
+        if (photoHasId)
+        {
+            exifTool.ContentIdentifiers["photo"] = "ABC-123";
+        }
+        if (videoHasId)
+        {
+            exifTool.ContentIdentifiers["video"] = "ABC-123";
+        }
+        var validator = new PairValidator(exifTool);
+
+        var result = await validator.ValidateAsync(MakePair(), TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsAccepted);
+        Assert.Contains(result.Reasons, r => r.Contains("仅"));
+    }
+
+    /// <summary>
     /// 无 ContentIdentifier 但拍摄时间差在 3 秒内应通过
     /// </summary>
     [Fact]
@@ -167,6 +192,9 @@ public class PairValidatorTests
 
         public Task<TimeSpan?> TryReadDurationAsync(string filePath, CancellationToken cancellationToken = default) =>
             Task.FromResult(VideoDuration);
+
+        public Task<bool> IsMirroredVideoAsync(string videoPath, CancellationToken cancellationToken = default) =>
+            Task.FromResult(false);
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }


### PR DESCRIPTION
## 概述

修复两个问题：

### 1. 前置摄像头自拍视频方向颠倒
- 现象：iPhone 前置摄像头拍摄的实况照片，合成动态照片后内嵌视频方向错误（竖屏左右颠倒、横屏上下颠倒）。
- 根因：前置摄像头视频的 QuickTime 变换矩阵行列式为负（含镜像），后置摄像头为纯旋转（行列式为正）。合成 MP4 走 `-c:v copy` 无损换容器时镜像矩阵被原样保留，而安卓相册等 MP4 播放器不识别镜像矩阵。
- 修复：合成前用 ExifTool 读取矩阵并计算 `det = a*d - b*c`，`det < 0` 时改走 FFmpeg 重新编码（由 autorotate 把镜像与旋转一起烧进像素），否则保持无损换容器。

### 2. 同名不同内容照片被错误配对
- 现象：目录里存在同名但不同内容的照片（如 `IMG_0435.JPG` 与 `IMG_0435.JPEG`）时，按扩展名盲选会把不相关的照片和视频封装成一张动态照片。
- 修复：
  - `PairValidator` 对「仅单边存在 ContentIdentifier」直接拒绝（真正的实况照片两边都有且一致）；
  - `MediaPairMatcher` 保留同名多候选并按扩展名优先级排序，`MotionPhotoMerger` 逐个校验后只合成每组第一个通过者。

## 测试

- `dotnet test`：96/96 通过（新增 10 个用例）。
- 真实相册批量验证：iCloud 上共 689 张实况照片，最终合并出 686 张动态照片，误差约 0.4%（1% 以内）。

## ⚠️ 合并前请慎重

这只是一个**粗略的测试**，并不能保证一定完全没有问题。此修复仅在我本地环境测试通过，
仅供参考思路，请原作者**慎重合并**。合并前建议：
- 用更多真实 iPhone 前置/后置实况照片回归（尤其是 HEIC 源照片、不同 iOS 版本的变换矩阵）；
- 在小米/Google 相册真机上确认内嵌视频方向；
- 评估「前置视频改走重新编码」带来的画质/耗时取舍，以及「仅单边 ContentIdentifier 即拒绝」是否会误伤被第三方工具处理过、丢失 ContentIdentifier 的照片。